### PR TITLE
Build and distribute Docker image

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          target: deploy
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,0 +1,48 @@
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docker-build:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          target: deploy
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64
+          cache-from: type=gha,scope=${{ github.workflow }}
+          cache-to: type=gha,mode=max,scope=${{ github.workflow }}

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -42,6 +42,6 @@ jobs:
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha,scope=${{ github.workflow }}
           cache-to: type=gha,mode=max,scope=${{ github.workflow }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
-FROM denoland/deno:latest
+FROM denoland/deno:alpine
 
 # The port that your application listens to.
 EXPOSE 43385
 
+VOLUME [ "/logs" ]
+
 WORKDIR /app
+
+# Symlink stats.json into a volume, as it's hard to mount from the workdir
+RUN mkdir /logs && ln -s /logs/stats.json ./stats.json && chown -R deno:deno /logs
 
 # Prefer not to run as root.
 USER deno
 
-CMD ["run", "--allow-all", "https://raw.githubusercontent.com/garrettjoecox/anchor/main/mod.ts"]
+# Copy in source code
+COPY *.ts .
+
+# Compile the main app so that it doesn't need to be compiled each startup/entry.
+RUN deno cache mod.ts
+
+CMD ["run", "--allow-net", "--allow-env", "--allow-write", "mod.ts"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ deno run --allow-net --allow-read mod.ts
 +"gRemoteGIIP": "127.0.0.1",
 ```
 
+### Docker
+
+```sh
+docker run -p 43385:43385 -v /my/mnt/logs:/logs ghcr.io/garrettjoecox/anchor:latest
+```
+
+Optional environment variables can be set:
+
+- `PORT`: configures the server port inside the container; defaults to `43385`
+- `QUIET`: when set, fewer log messages are output; defaults to unset
+
 ## Packet protocol
 
 > This is for anyone wanting to extend the client side of anchor while still


### PR DESCRIPTION
- Adds Github Actions to build and push image to Github container registry.
  - When merged, it should just work automatically without any tokens to be setup. 
  - You can see how it gets shown [on my fork](https://github.com/claabs?tab=packages&repo_name=anchor)
  - Runs on push to `main`
- Improve Dockerfile
  - Adds a symlink for `stats.json` so it can be mounted easier (no need to prime the mount with an empty `stats.json`)
  - Add `deno cache` as recommended by the [official deno Docker image docs](https://github.com/denoland/deno_docker?tab=readme-ov-file#as-a-dockerfile)
  - Switch to the `alpine` base image for a smaller size
- Add Readme section for Docker setup