### PR TITLE
Ban list and clientSHAs

### DIFF
--- a/client.go
+++ b/client.go
@@ -45,7 +45,8 @@ func (c *Client) handlePacket(packet string) {
 
 	if packetType == "GAME_COMPLETE" {
 		c.server.mu.Lock()
-		c.server.gamesCompleted++
+		c.server.totalGamesComplete++
+		c.server.monthlyGamesComplete++
 		c.server.mu.Unlock()
 	}
 

--- a/server.go
+++ b/server.go
@@ -260,6 +260,7 @@ func (s *Server) handleConnection(conn net.Conn, errChan chan error) {
 		if invalidCount >= BANNABLE_INVALID_PACKET_LIMIT {
 			s.banIP(strings.Split(conn.RemoteAddr().String(), ":")[0])
 			s.handleBannedConnection(conn)
+			continue
 		}
 		packet := scanner.Text()
 


### PR DESCRIPTION
- Added a method to ban ips (stored as SHA)
- Ported clientSHAS functionality from stable server
- Fixed up some poorly written code in the commands (was previously written for use with slices not maps)
- Added stats (monthlyGamesComplete and clientSHAs) that will refresh monthly (I think. Check it out and tell me if you think it will work.)

I think we should wait to merge this until we fix that pesky deadlock.