### PR TITLE
Clarify deno version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You don't technically need this, I'm hosting this on my end. Instead see
 
 If you would like to host your own server:
 
-- [Install deno](https://docs.deno.com/runtime/manual/getting_started/installation)
+- [Install deno (a pre-2.0.0 version)](https://docs.deno.com/runtime/manual/getting_started/installation)
 - If you don't want to make any code changes, you can run it straight from
   github with
 


### PR DESCRIPTION
A few people have reported issues with running the Deno server because they're on Deno 2.x.

This adds a note that Deno 2.x won't work. (I understand that this will be mostly obsolete once the Go server is the main server)